### PR TITLE
Add MathWallet

### DIFF
--- a/src/services.js
+++ b/src/services.js
@@ -21,6 +21,7 @@ export function initOnboard(subscriptions) {
     walletSelect: {
       wallets: [
         { walletName: 'metamask' },
+        { walletName: 'mathwallet' },
         {
           walletName: 'trezor',
           appUrl: 'https://reactdemo.blocknative.com',


### PR DESCRIPTION
MathWallet website [https://mathwallet.org](https://mathwallet.org)

MathWallet is a multi-platform (mobile/desktop) universal crypto wallet that has 2 Million users and enables token storage of 60+ chains including ETH, Polkadot, Solana, BinanceChain, Polygon etc. Our investors includes Fenbushi Capital, Alameda Research, Binance Labs, FundamentalLabs, Multicoin Capital.

MathWallet has both mobile app on iPhone and Android, also has browser extension wallet.

For iOS app, because of AppleStore guideline, we cannot add dapp at the moment. User need to visit our dappstore https://mathdapp.store and scan the dapp QRcode to open it in the app.
For testing, you can use MathWallet to scan below qrcode and open the dapp browser.

[http://qiniu.eth.fm/2021-09-16-dappbrowser.png](http://qiniu.eth.fm/2021-09-16-dappbrowser.png)

Any questions, feel free to let us know.

Thanks!