### PR TITLE
0.21.0 Release - Develop

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "onboard-notify-react",
-  "version": "0.20.1-0.1.0",
+  "version": "0.21.0",
   "dependencies": {
     "@craco/craco": "^5.8.3",
     "@web3-onboard/coinbase": "^2.0.5-alpha.1",


### PR DESCRIPTION
- Add Transaction and DApp Notifications to W3O along with documentation on usage #1070 
- Adds optional public RPC and Block Explorer Chain Params #1021 
- Convert `background-color` to `background` for css properties with exposed variables for greater customization #1074 
- Fix build issues occurring within the React Package #1075 
- Remove ES 8 > operators #1082 
- Fix web3-auth build issue within CI #1085 
For full release notes - https://github.com/blocknative/web3-onboard/releases/tag/web3-onboard%2F2.1.0